### PR TITLE
support custom tags without selectors

### DIFF
--- a/src/dekao.nim
+++ b/src/dekao.nim
@@ -64,6 +64,9 @@ template voidTag*(selector, name: string, inner) =
   inner
   say "<" & name & attrsStack.pop() & "/>"
 
+template tag*(name: string, inner) = tag "", name, inner
+template voidTag*(name: string, inner) = voidTag "", name, inner
+
 template a*(selector = "", inner) = tag selector, "a", inner
 template abbr*(selector = "", inner) = tag selector, "abbr", inner
 template acronym*(selector = "", inner) = tag selector, "acronym", inner


### PR DESCRIPTION
Without this the use of custom elements (web components) requires a selector string, even an empty one. This removes that requirement, allowing `tag "custom-element":` directly, as one might expect.